### PR TITLE
Add -sync-modules option to load salt-sproxy execution modules 

### DIFF
--- a/Dockerfile-all
+++ b/Dockerfile-all
@@ -7,4 +7,4 @@ COPY ./roster /etc/salt/roster
 COPY --from=napalmautomation/napalm:develop /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
 COPY --from=napalmautomation/napalm:develop /usr/local/bin/napalm /usr/local/bin/napalm
 
-RUN pip --no-cache-dir install ciscoconfparse==1.3.39 jxmlease==1.0.1 scp==0.13.2 ansible==2.8.1 pynetbox==3.4.11
+RUN pip --no-cache-dir install ciscoconfparse==1.3.39 jxmlease==1.0.1 scp==0.13.2 ansible==2.8.1 pynetbox==4.0.6

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include pypi.rst
 include docs/man/*
 include requirements.txt
 include salt_sproxy/_runners/*
+include salt_sproxy/_modules/*
 include salt_sproxy/_roster/*

--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -94,6 +94,18 @@ already familiar with a vast majority of them from the `salt
     Synchronise the Roster modules (both salt-sproxy native and provided by the
     user in their own environment). Default: ``True``.
 
+.. option:: --sync-modules
+
+    .. versionadded:: 2019.9.0
+
+    Load the Execution modules provided together with salt-sproxy. Beware that
+    it may override the Salt native modules, or your own extension modules.
+    Default: ``False``.
+
+    You can also add ``sync_modules: true`` into the Master config file, if you
+    want to always ensure that salt-sproxy is using the Execution modules
+    delivered with this package.
+
 .. option:: --events
 
      Whether should put the events on the Salt bus (mostly useful when having a

--- a/salt_sproxy/_modules/netbox.py
+++ b/salt_sproxy/_modules/netbox.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+'''
+NetBox
+======
+
+Module to query NetBox
+
+:codeauthor: Zach Moody <zmoody@do.co>
+:maturity:   new
+:depends:    pynetbox
+
+The following config should be in the minion config file. In order to
+work with ``secrets`` you should provide a token and path to your
+private key file:
+
+.. code-block:: yaml
+
+  netbox:
+    url: <NETBOX_URL>
+    token: <NETBOX_USERNAME_API_TOKEN (OPTIONAL)>
+    keyfile: </PATH/TO/NETBOX/KEY (OPTIONAL)>
+
+.. versionadded:: 2018.3.0
+'''
+
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+try:
+    import pynetbox
+
+    HAS_PYNETBOX = True
+except ImportError:
+    HAS_PYNETBOX = False
+
+AUTH_ENDPOINTS = (
+    'secrets',
+)
+
+
+def __virtual__():
+    '''
+    pynetbox must be installed.
+    '''
+    if not HAS_PYNETBOX:
+        return (
+            False,
+            'The netbox execution module cannot be loaded: '
+            'pynetbox library is not installed.'
+        )
+    else:
+        return True
+
+
+def _config():
+    config = __salt__['config.get']('netbox')
+    if not config:
+        raise CommandExecutionError(
+            'NetBox execution module configuration could not be found'
+        )
+    return config
+
+
+def _nb_obj(auth_required=False):
+    pynb_kwargs = {}
+    if auth_required:
+        pynb_kwargs['token'] = _config().get('token')
+        pynb_kwargs['private_key_file'] = _config().get('keyfile')
+    return pynetbox.api(_config().get('url'), **pynb_kwargs)
+
+
+def _strip_url_field(input_dict):
+    if 'url' in input_dict.keys():
+        del input_dict['url']
+    for k, v in input_dict.items():
+        if isinstance(v, dict):
+            _strip_url_field(v)
+    return input_dict
+
+
+def filter(app, endpoint, **kwargs):
+    '''
+    Get a list of items from NetBox.
+
+    .. code-block:: bash
+
+        salt myminion netbox.filter dcim devices status=1 role=router
+    '''
+    ret = []
+    nb = _nb_obj(auth_required=True if app in AUTH_ENDPOINTS else False)
+    clean_kwargs = __utils__['args.clean_kwargs'](**kwargs)
+    nb_query = None
+    if not clean_kwargs:
+        nb_query = getattr(getattr(nb, app), endpoint).all()
+    else:
+        nb_query = getattr(getattr(nb, app), endpoint).filter(**clean_kwargs)
+    if nb_query:
+        ret = [_strip_url_field(dict(i)) for i in nb_query]
+    return ret
+
+
+def get(app, endpoint, id=None, **kwargs):
+    '''
+    Get a single item from NetBox.
+
+    To get an item based on ID.
+
+    .. code-block:: bash
+
+        salt myminion netbox.get dcim devices id=123
+
+    Or using named arguments that correspond with accepted filters on
+    the NetBox endpoint.
+
+    .. code-block:: bash
+
+        salt myminion netbox.get dcim devices name=my-router
+    '''
+    nb = _nb_obj(auth_required=True if app in AUTH_ENDPOINTS else False)
+    if id:
+        return dict(getattr(getattr(nb, app), endpoint).get(id))
+    else:
+        clean_kwargs = __utils__['args.clean_kwargs'](**kwargs)
+        return dict(
+            getattr(getattr(nb, app), endpoint).get(**clean_kwargs)
+        )

--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -132,6 +132,15 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
         runner_path = os.path.join(curpath, '_runners')
         runner_dirs.append(runner_path)
         self.config['runner_dirs'] = runner_dirs
+        if self.config.get('sync_modules', False):
+            # Don't sync modules by default
+            log.debug('Syncing modules')
+            module_dirs = self.config.get('module_dirs', [])
+            module_path = os.path.join(curpath, '_modules')
+            module_dirs.append(module_path)
+            self.config['module_dirs'] = module_dirs
+            # No need to explicitly load the modules here, as during runtime,
+            # Salt is anyway going to load the modules on the fly.
         # Resync Roster module to load the ones we have here in the library, and
         # potentially others provided by the user in their environment
         if self.config.get('sync_roster', True):

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -239,6 +239,14 @@ class SaltStandaloneProxyOptionParser(
             help='Show the devices expected to match the target.',
         )
         self.add_option(
+            '--sync-modules',
+            dest='sync_modules',
+            action='store_true',
+            help=(
+                'Load the salt-sproxy Execution modules.'
+            ),
+        )
+        self.add_option(
             '--sync-roster',
             dest='sync_roster',
             action='store_true',


### PR DESCRIPTION
This would allow us to port modules from Salt, whose patches are still pending to be merged, e.g., https://github.com/saltstack/salt/pull/52631

This should normally help with issues such as #40 which are failing due to discrepancy between the version required for the Salt netbox module to run and pynetbox.