### PR TITLE
Implement --failhard, --summary, and --timeout options

### DIFF
--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -156,6 +156,12 @@ already familiar with a vast majority of them from the `salt
 
     The number of devices to connect to in parallel.
 
+.. option:: --failhard
+
+    .. versionadded:: 2019.12.0
+
+    Stop the execution at the first error.
+
 .. option:: --preview-target
 
     Show the devices expected to match the target, without executing any 

--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -156,6 +156,32 @@ already familiar with a vast majority of them from the `salt
 
     The number of devices to connect to in parallel.
 
+.. option:: --batch-wait
+
+    .. versionadded:: 2020.1.0
+
+    Wait a specific number of seconds after each batch is done before executing 
+    the next one.
+
+.. option:: -p, --progress
+
+    .. versionadded:: 2020.1.0
+
+    Display a progress graph to visually show the execution of the command 
+    across the list of devices.
+
+    .. note::
+
+        As of release 2020.1.0, the best experience of using the progress graph 
+        is in conjunction with the ``-s`` / ``--static`` option, otherwise 
+        there's a small display issue.
+
+.. option:: --hide-timeout
+
+    .. versionadded:: 2020.1.0
+
+    Hide devices that timeout.
+
 .. option:: --failhard
 
     .. versionadded:: 2020.1.0
@@ -177,6 +203,9 @@ already familiar with a vast majority of them from the `salt
     - Number of unreachable devices (i.e., couldn't establish the connection 
       with the remote device).
 
+    In ``-v`` / ``--verbose`` mode, this output is enahnced by displaying the 
+    list of devices that did not return / with errors / unreachable.
+
     Example:
 
     .. code-block:: text
@@ -190,6 +219,19 @@ already familiar with a vast majority of them from the `salt
         # of devices with errors: 0
         # of devices unreachable: 2
         -------------------------------------------
+
+.. option:: --show-jid
+
+    .. versionadded:: 2020.1.0
+
+    Display jid without the additional output of --verbose.
+
+.. option:: -v, --verbose
+
+    .. versionadded:: 2020.1.0
+
+    Turn on command verbosity, display jid, devices per batch, and detailed
+    summary.
 
 .. option:: --preview-target
 

--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -166,7 +166,16 @@ already familiar with a vast majority of them from the `salt
 
     .. versionadded:: 2020.1.0
 
-    Display a summary of the command execution.
+    Display a summary of the command execution:
+
+    - Total number of devices targeted.
+    - Number of devices that returned without issues.
+    - Number of devices that timed out executing the command. See also ``-t`` 
+      or ``--timeout`` argument to adjust the timeout value.
+    - Number of devices with errors (i.e., there was an error while executing 
+      the command).
+    - Number of unreachable devices (i.e., couldn't establish the connection 
+      with the remote device).
 
     Example:
 

--- a/docs/opts.rst
+++ b/docs/opts.rst
@@ -36,7 +36,7 @@ already familiar with a vast majority of them from the `salt
 
 .. config:: --config-dump
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
     Print the complete salt-sproxy configuration values (with the defaults), as 
     YAML.
@@ -103,7 +103,7 @@ already familiar with a vast majority of them from the `salt
 
 .. option:: --sync
 
-    .. versionremoved:: 2019.12.0
+    .. versionremoved:: 2020.1.0
 
         This option has been replaced by ``--static`` (see below).
 
@@ -112,7 +112,7 @@ already familiar with a vast majority of them from the `salt
 
 .. option:: -s, --static
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
         Starting with this release, ``--static``, replaces the previous CLI
         option ``--sync``, with the same functionality.
@@ -158,9 +158,29 @@ already familiar with a vast majority of them from the `salt
 
 .. option:: --failhard
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
     Stop the execution at the first error.
+
+.. option:: --summary
+
+    .. versionadded:: 2020.1.0
+
+    Display a summary of the command execution.
+
+    Example:
+
+    .. code-block:: text
+
+        -------------------------------------------
+        Summary
+        -------------------------------------------
+        # of devices targeted: 10
+        # of devices returned: 3
+        # of devices that did not return: 5
+        # of devices with errors: 0
+        # of devices unreachable: 2
+        -------------------------------------------
 
 .. option:: --preview-target
 
@@ -281,25 +301,25 @@ already familiar with a vast majority of them from the `salt
 
 .. option:: --pillar-root
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
     Set a specific directory as the base pillar root.
 
 .. option:: --file-root
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
     Set a specific directory as the base file root.
 
 .. option:: --states-dir
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
     Set a specific directory to search for additional States.
 
 .. option:: -m, --module-dirs
 
-    .. versionadded:: 2019.12.0
+    .. versionadded:: 2020.1.0
 
     Specify one or more directories where to load the extension modules from.
     Multiple directories can be provided by passing ``-m`` or 
@@ -411,11 +431,11 @@ Output Options
     using the Python ``pprint`` standard library module.
 
     .. note::
-        If using ``--out=json``, you will probably want ``--sync`` as well.
+        If using ``--out=json``, you will probably want ``--static`` as well.
         Without the sync option, you will get a separate JSON string per minion
         which makes JSON output invalid as a whole.
         This is due to using an iterative outputter. So if you want to feed it
-        to a JSON parser, use ``--sync`` as well.
+        to a JSON parser, use ``--static`` as well.
 
 .. option:: --out-indent OUTPUT_INDENT, --output-indent OUTPUT_INDENT
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 salt
+progressbar2

--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -86,7 +86,15 @@ is_proxy = _is_proxy
 
 
 def _salt_call_and_return(
-    minion_id, function, queue, unreachable_devices, failed_devices, arg=None, jid=None, events=True, **opts
+    minion_id,
+    function,
+    queue,
+    unreachable_devices,
+    failed_devices,
+    arg=None,
+    jid=None,
+    events=True,
+    **opts
 ):
     '''
     '''
@@ -283,7 +291,10 @@ class SProxyMinion(SMinion):
             try:
                 proxy_init_fn(self.opts)
             except Exception as exc:
-                log.error('Encountered error when starting up the connection with %s:', self.opts['id'])
+                log.error(
+                    'Encountered error when starting up the connection with %s:',
+                    self.opts['id'],
+                )
                 if self.unreachable_devices:
                     self.unreachable_devices.append(self.opts['id'])
                 raise
@@ -316,7 +327,9 @@ class SProxyMinion(SMinion):
 
 
 class StandaloneProxy(SProxyMinion):
-    def __init__(self, opts, unreachable_devices=None):  # pylint: disable=super-init-not-called
+    def __init__(
+        self, opts, unreachable_devices=None
+    ):  # pylint: disable=super-init-not-called
         self.opts = opts
         self.ready = False
         self.unreachable_devices = unreachable_devices
@@ -764,7 +777,16 @@ def execute_devices(
                 device_proc = multiprocessing.Process(
                     target=_salt_call_and_return,
                     name=minion_id,
-                    args=(minion_id, function, queue, unreachable_devices, failed_devices, event_args, jid, events),
+                    args=(
+                        minion_id,
+                        function,
+                        queue,
+                        unreachable_devices,
+                        failed_devices,
+                        event_args,
+                        jid,
+                        events,
+                    ),
                     kwargs=device_opts,
                 )
                 device_proc.start()
@@ -804,14 +826,28 @@ def execute_devices(
             return resp
         if summary:
             salt.utils.stringutils.print_cli('\n')
-            salt.utils.stringutils.print_cli('-------------------------------------------')
+            salt.utils.stringutils.print_cli(
+                '-------------------------------------------'
+            )
             salt.utils.stringutils.print_cli('Summary')
-            salt.utils.stringutils.print_cli('-------------------------------------------')
-            salt.utils.stringutils.print_cli('# of devices targeted: {0}'.format(len(minions)))
-            salt.utils.stringutils.print_cli('# of devices that did not return: {0}'.format(len(timeout_devices)))
-            salt.utils.stringutils.print_cli('# of devices with errors: {0}'.format(len(failed_devices)))
-            salt.utils.stringutils.print_cli('# of devices unreachable: {0}'.format(len(unreachable_devices)))
-            salt.utils.stringutils.print_cli('-------------------------------------------')
+            salt.utils.stringutils.print_cli(
+                '-------------------------------------------'
+            )
+            salt.utils.stringutils.print_cli(
+                '# of devices targeted: {0}'.format(len(minions))
+            )
+            salt.utils.stringutils.print_cli(
+                '# of devices that did not return: {0}'.format(len(timeout_devices))
+            )
+            salt.utils.stringutils.print_cli(
+                '# of devices with errors: {0}'.format(len(failed_devices))
+            )
+            salt.utils.stringutils.print_cli(
+                '# of devices unreachable: {0}'.format(len(unreachable_devices))
+            )
+            salt.utils.stringutils.print_cli(
+                '-------------------------------------------'
+            )
     return ''
 
 

--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -845,7 +845,7 @@ def execute_devices(
                 '# of devices targeted: {0}'.format(len(minions))
             )
             salt.utils.stringutils.print_cli(
-                '# of minions returned: {0}'.format(
+                '# of devices returned: {0}'.format(
                     len(minions) - len(timeout_devices) - len(unreachable_devices)
                 )
             )

--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -806,8 +806,7 @@ def execute_devices(
                     continue
                 if failhard and proc.exitcode:
                     stop_iteration = True
-                if timeout:
-                    proc.join(timeout=timeout)
+                proc.join(timeout=timeout)
                 if proc.is_alive():
                     log.info(
                         'Terminating the process for %s, as it didn\'t reply within %d seconds',
@@ -1013,6 +1012,13 @@ def execute(
     targets = []
     rtargets = None
     roster = roster or __opts__.get('proxy_roster', __opts__.get('roster'))
+
+    if not timeout:
+        log.warning('Timeout set as 0, will wait for the devices to reply indefinitely')
+        # Setting the timeout as None, because that's the value we need to pass
+        # to multiprocessing's join() method to wait for the devices to reply
+        # indefinitely.
+        timeout = None
 
     if preload_targeting or invasive_targeting:
         _tgt = '*'

--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -226,6 +226,8 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
             'timeout',
             'static',
             'no_connect',
+            'failhard',
+            'summary',
         )
         for kwargs_opt in kwargs_opts:
             if getattr(self.options, kwargs_opt) is not None:

--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -258,6 +258,7 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
         )
         kwargs['preload_targeting'] = self.config.get('preload_targeting', False)
         kwargs['invasive_targeting'] = self.config.get('invasive_targeting', False)
+        kwargs['failhard'] = self.config.get('failhard', False)
         self.config['arg'] = [tgt, fun, kwargs]
         runner = salt.runner.Runner(self.config)
 

--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -221,6 +221,7 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
         kwargs_opts = (
             'preview_target',
             'batch_size',
+            'batch_wait',
             'cache_grains',
             'cache_pillar',
             'roster',
@@ -229,6 +230,9 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
             'no_connect',
             'failhard',
             'summary',
+            'verbose',
+            'show_jid',
+            'hide_timeout',
             'progress',
         )
         for kwargs_opt in kwargs_opts:

--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -134,12 +134,14 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
         tgt = self.config['tgt']
         fun = self.config['fun']
         args = self.config['arg']
+        kwargs = {}
         if 'output' not in self.config and fun in (
             'state.sls',
             'state.apply',
             'state.highstate',
         ):
             self.config['output'] = 'highstate'
+        kwargs['progress'] = self.config.pop('progress', False)
         # To be able to reuse the proxy Runner (which is not yet available
         # natively in Salt), we can override the ``runner_dirs`` configuration
         # option to tell Salt to load that Runner too. This way, we can also
@@ -197,7 +199,6 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
             states_dirs.append(self.config['states_dir'])
             self.config['states_dirs'] = states_dirs
         self.config['fun'] = 'proxy.execute'
-        kwargs = {}
         tmp_args = args[:]
         for index, arg in enumerate(tmp_args):
             if isinstance(arg, dict) and '__kwarg__' in arg:
@@ -228,6 +229,7 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
             'no_connect',
             'failhard',
             'summary',
+            'progress',
         )
         for kwargs_opt in kwargs_opts:
             if getattr(self.options, kwargs_opt) is not None:

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -121,7 +121,7 @@ class SaltStandaloneProxyOptionParser(
     )
 ):
 
-    default_timeout = 1
+    default_timeout = 60
 
     description = (
         '''

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -428,6 +428,13 @@ class SaltStandaloneProxyOptionParser(
             action='store_true',
             help='Display salt execution summary information.',
         )
+        self.add_option(
+            '-p',
+            '--progress',
+            default=False,
+            action='store_true',
+            help='Display a progress graph.',
+        )
 
     # Everything else that follows here is verbatim copy from
     # https://github.com/saltstack/salt/blob/develop/salt/utils/parsers.py

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -429,6 +429,34 @@ class SaltStandaloneProxyOptionParser(
             help='Display salt execution summary information.',
         )
         self.add_option(
+            '-v',
+            '--verbose',
+            default=False,
+            action='store_true',
+            help='Turn on command verbosity, display jid and detailed summary.',
+        )
+        self.add_option(
+            '--show-jid',
+            default=False,
+            action='store_true',
+            help='Display jid without the additional output of --verbose.',
+        )
+        self.add_option(
+            '--hide-timeout',
+            default=False,
+            action='store_true',
+            help='Hide devices that timeout.',
+        )
+        self.add_option(
+            '--batch-wait',
+            default=0,
+            type=float,
+            help=(
+                'Wait the specified time in seconds after each batch is done'
+                'before executing the next one.'
+            ),
+        )
+        self.add_option(
             '-p',
             '--progress',
             default=False,

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -421,7 +421,12 @@ class SaltStandaloneProxyOptionParser(
             action='store_true',
             help='Do not display the results of the run.',
         )
-
+        self.add_option(
+            '--summary',
+            default=False,
+            action='store_true',
+            help='Display salt execution summary information.',
+        )
     # Everything else that follows here is verbatim copy from
     # https://github.com/saltstack/salt/blob/develop/salt/utils/parsers.py
     def _mixin_after_parsed(self):

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -165,7 +165,8 @@ class SaltStandaloneProxyOptionParser(
             help='Absolute path to the Roster file to use.',
         )
         self.add_option(
-            '-s', '--static',
+            '-s',
+            '--static',
             default=False,
             action='store_true',
             help=('Return the data from devices as a group after they all return.'),
@@ -427,6 +428,7 @@ class SaltStandaloneProxyOptionParser(
             action='store_true',
             help='Display salt execution summary information.',
         )
+
     # Everything else that follows here is verbatim copy from
     # https://github.com/saltstack/salt/blob/develop/salt/utils/parsers.py
     def _mixin_after_parsed(self):

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -396,6 +396,13 @@ class SaltStandaloneProxyOptionParser(
             ),
         )
         self.add_option(
+            '--failhard',
+            dest='failhard',
+            action='store_true',
+            default=False,
+            help='Stop execution at the first execution error',
+        )
+        self.add_option(
             '--no-target-cache',
             dest='no_target_cache',
             action='store_true',


### PR DESCRIPTION
Can now do stuff like:

```bash
$ salt-sproxy -E 'minion9\d' test.rand_sleep 60 --summary -t 5
minion97:
    True
minion95:
    True
minion94:
    True


-------------------------------------------
Summary
-------------------------------------------
# of devices targeted: 10
# of minions returned: 3
# of devices that did not return: 5
# of devices with errors: 0
# of devices unreachable: 2
-------------------------------------------
```