### PR TITLE
Optimise the cache-based targeting

### DIFF
--- a/salt_sproxy/_roster/file.py
+++ b/salt_sproxy/_roster/file.py
@@ -29,13 +29,15 @@ def targets(tgt, tgt_type='glob', **kwargs):
     '''
     template = get_roster_file(__opts__)
     rend = salt.loader.render(__opts__, {})
-    pool = compile_template(template,
-                            rend,
-                            __opts__['renderer'],
-                            __opts__['renderer_blacklist'],
-                            __opts__['renderer_whitelist'],
-                            mask_value='passw*',
-                            **kwargs)
+    pool = compile_template(
+        template,
+        rend,
+        __opts__['renderer'],
+        __opts__['renderer_blacklist'],
+        __opts__['renderer_whitelist'],
+        mask_value='passw*',
+        **kwargs
+    )
     pool = {host: {'minion_opts': conf} for host, conf in pool.items()}
     pool = salt_sproxy._roster.load_cache(
         pool, __runner__, __opts__, tgt, tgt_type=tgt_type

--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -327,9 +327,7 @@ class SProxyMinion(SMinion):
                 # After loading, merge with the previous loaded grains, which
                 # may contain other grains from different sources, e.g., roster.
                 loaded_grains = salt.loader.grains(self.opts, proxy=self.proxy)
-                self.opts['grains'] = salt.utils.dictupdate.merge(
-                    grains, loaded_grains
-                )
+                self.opts['grains'] = salt.utils.dictupdate.merge(grains, loaded_grains)
             self.functions.pack['__grains__'] = copy.deepcopy(self.opts['grains'])
         self.grains_cache = copy.deepcopy(self.opts['grains'])
 
@@ -595,7 +593,11 @@ def salt_call(
         if returner:
             returner_fun = '{}.returner'.format(returner)
             if returner_fun in sa_proxy.returners:
-                log.error('Sending the response from %s to the %s Returner', opts['id'], returner)
+                log.error(
+                    'Sending the response from %s to the %s Returner',
+                    opts['id'],
+                    returner,
+                )
                 ret_data = {
                     'id': opts['id'],
                     'jid': jid,
@@ -608,10 +610,16 @@ def salt_call(
                 try:
                     sa_proxy.returners[returner_fun](ret_data)
                 except Exception as err:
-                    log.error('Exception while sending the response from %s to the %s returner', opts['id'], returner)
+                    log.error(
+                        'Exception while sending the response from %s to the %s returner',
+                        opts['id'],
+                        returner,
+                    )
                     log.error(err, exc_info=True)
             else:
-                log.warning('Returner %s is not available. Check that the dependencies are properly installed')
+                log.warning(
+                    'Returner %s is not available. Check that the dependencies are properly installed'
+                )
     finally:
         if sa_proxy.connected:
             shut_fun = '{}.shutdown'.format(sa_proxy.opts['proxy']['proxytype'])
@@ -1206,11 +1214,7 @@ def execute(
                 log.debug('Gathering the cached Grains from the existing Minions')
                 cache_grains = __salt__['cache.grains'](tgt=tgt, tgt_type=tgt_type)
                 for target, target_grains in cache_grains.items():
-                    rtargets[target] = {
-                        'minion_opts': {
-                            'grains': target_grains
-                        }
-                    }
+                    rtargets[target] = {'minion_opts': {'grains': target_grains}}
             log.debug('Computing the target using the %s Roster', roster)
             __opts__['use_cached_grains'] = use_cached_grains
             __opts__['use_cached_pillar'] = use_cached_pillar


### PR DESCRIPTION
Avoid loading cached Grains or Pillar when not necessary - for example,
when the target type is a list or glob, there's no need to load cache at
all, while when targeting using Grains only, it's best to avoid loading
Pillar, etc.