### PR TITLE
Fixed typo in cli import

### DIFF
--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -39,7 +39,10 @@ try:
     from salt.utils.profile import output_profile
     from salt.utils.profile import activate_profile
 except ImportError:
-    from salt.utils import fopen
+    try:
+        from salt.utils.file import fopen # support for prior to salt 3000
+    except ImportError:
+        from salt.utils import fopen
     from salt.utils.yamldumper import safe_dump
     from salt.utils.yamlloader import load as safe_load
     from salt.utils import output_profile

--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -33,7 +33,7 @@ import salt.defaults.exitcodes  # pylint: disable=W0611
 import salt.utils.stringutils
 
 try:
-    from salt.utils.file import fopen
+    from salt.utils.files import fopen
     from salt.utils.yamldumper import safe_dump
     from salt.utils.yamlloader import safe_load
     from salt.utils.profile import output_profile


### PR DESCRIPTION


This addresses an issue in `cli.py` for a failing import for `salt.utils.file` instead of `salt.utils.files`. 