### PR TITLE
Explicit return when the Minion is not connected

### DIFF
--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -910,6 +910,14 @@ def execute_devices(
                 ', '.join(cli_batch.down_minions),
             )
             down_minions = cli_batch.down_minions
+            for minion in down_minions:
+                ret_queue.put(
+                    (
+                        {minion: 'Minion did not return. [Not connected]'},
+                        salt.defaults.exitcodes.EX_UNAVAILABLE,
+                    )
+                )
+
     log.info(
         '%d devices matched the target, executing in %d batches',
         len(minions),


### PR DESCRIPTION
We're currently just logging a warning, it'd be more useful to return an
explicit message when the Minion is not connected. This is when
executing against executing against running (Proxy) Minions.