### PR TITLE
Copy code across from the NetBox module to avoid dependency 

### DIFF
--- a/docs/releases/2020.4.0.rst
+++ b/docs/releases/2020.4.0.rst
@@ -1,0 +1,16 @@
+.. _release-2020.4.0:
+
+================
+Release 2020.4.0
+================
+
+Explicit return when the Minion is not connected
+------------------------------------------------
+
+When using *salt-sproxy* to execute against running (Proxy) Minions, it may 
+happen sometimes that the Minion is not available for various reasons (e.g., 
+key accepted, but the service is not fully started, etc.). When this happens, 
+*salt-sprox* now returns an explicit message ``Minion did not return. [Not 
+connected]`` for better feedback on the command line.
+
+

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -10,7 +10,7 @@ Latest Release
 .. toctree::
    :maxdepth: 1
 
-   2020.3.0
+   2020.4.0
 
 Previous Releases
 ^^^^^^^^^^^^^^^^^
@@ -18,5 +18,6 @@ Previous Releases
 .. toctree::
    :maxdepth: 1
 
+   2020.3.0
    2020.2.0
    2019.10.0


### PR DESCRIPTION
Closes #111.

In order to work around a bug in the Salt native module for NetBox, I've
ported the module over here to be shipped together with salt-sproxy.
The issue is that users bumped into a non-obvious dependency so they
have to run with ``--sync-module`` in order to have the NetBox Roster
pull the data properly.
One solution would be to just default ``--sync-modules`` to True, but
then any modules included in salt-sproxy would implicitly override what
the user has in their own environment - and I don't think that'd be the
best approach, as it may lead to unexpected results.
So I figured the only good approach would be to get rid of the
dependency of the NetBox Roster on the execution module and copy the
necessary bits across.