### PR TITLE
Merge Pillar/Roster opts into the Master opts for simplicity

### DIFF
--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -311,7 +311,10 @@ class SProxyMinion(SMinion):
             raise SaltSystemExit(code=salt.defaults.exitcodes.EX_GENERIC, msg=errmsg)
 
         if 'proxy' not in self.opts:
-            self.opts['proxy'] = self.opts['pillar']['proxy']
+            self.opts['proxy'] = {}
+        self.opts['proxy'] = salt.utils.dictupdate.merge(
+            self.opts['proxy'], self.opts['pillar']['proxy']
+        )
 
         # Then load the proxy module
         self.utils = salt.loader.utils(self.opts)


### PR DESCRIPTION
This allows to have the ``proxy:`` block specified directly into the
Master config, and more specifics into the Roster or Pillar. This makes
it easier as it removes the requirement to have a dedicated Pillar only
for the proxy auth.