### PR TITLE
Init proxy Pillar when not provided, but only Master opts

### DIFF
--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -312,6 +312,8 @@ class SProxyMinion(SMinion):
 
         if 'proxy' not in self.opts:
             self.opts['proxy'] = {}
+        if 'proxy' not in self.opts['pillar']:
+            self.opts['pillar']['proxy'] = {}
         self.opts['proxy'] = salt.utils.dictupdate.merge(
             self.opts['proxy'], self.opts['pillar']['proxy']
         )


### PR DESCRIPTION
Useful when providing the connection details through the Master config only.