### PR TITLE
Optimise the proxy loading during normal startup

### DIFF
--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -319,14 +319,16 @@ class SProxyMinion(SMinion):
         )
 
         # Then load the proxy module
+        fq_proxyname = self.opts['proxy']['proxytype']
         self.utils = salt.loader.utils(self.opts)
-        self.proxy = salt.loader.proxy(self.opts, utils=self.utils)
+        self.proxy = salt.loader.proxy(
+            self.opts, utils=self.utils, whitelist=[fq_proxyname]
+        )
         self.functions = salt.loader.minion_mods(
             self.opts, utils=self.utils, notify=False, proxy=self.proxy
         )
         self.functions.pack['__grains__'] = copy.deepcopy(self.opts['grains'])
 
-        fq_proxyname = self.opts['proxy']['proxytype']
         self.functions.pack['__proxy__'] = self.proxy
         self.proxy.pack['__salt__'] = self.functions
         self.proxy.pack['__pillar__'] = self.opts['pillar']

--- a/tests/run/master
+++ b/tests/run/master
@@ -46,3 +46,7 @@ grains:
   salt:
     role: proxy
     platform: sproxy
+
+disable_grains:
+  # disabling ESXI Grain module load due to https://github.com/saltstack/salt/issues/57811
+  - esxi


### PR DESCRIPTION
Optimise the salt-sproxy execution, by easing the standalone local PM
startup as it loads only the proxy module requested.