### PR TITLE
Update SaltStack version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-slim-stretch
 
 MAINTAINER ping@mirceaulinic.net
 
-ARG SALT_VERSION="2019.2.0"
+ARG SALT_VERSION="2019.2.5"
 
 COPY ./ /var/cache/salt-sproxy/
 COPY ./master /etc/salt/master


### PR DESCRIPTION
**What was done?**

Update SaltStack version.

**Why was it done?**

To remove the following warning messages for each interaction with network assets.

**Before:**

_[WARNING ] /usr/local/lib/python3.6/site-packages/salt/transport/ipc.py:292: DeprecationWarning: encoding is deprecated, Use raw=False instead.<br>
  self.unpacker = msgpack.Unpacker(encoding=encoding)
[WARNING ] /usr/local/lib/python3.6/site-packages/salt/payload.py:149: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  ret = msgpack.loads(msg, use_list=True, ext_hook=ext_type_decoder, encoding=encoding)
router1:
    ----------
    out:
        True_




**After:**

_router1:
    ----------
    out:
        True_
