### PR TITLE
Fix calling module functions with arguments when using a Saltfile

### DIFF
--- a/salt_sproxy/_proxy/ssh.py
+++ b/salt_sproxy/_proxy/ssh.py
@@ -105,8 +105,18 @@ def _prep_conn(opts, fun, *args, **kwargs):
     fsclient = salt.fileclient.FSClient(opts)
     # TODO: Have here more options to simplify the usage, through features like
     # auto-expand the path to the priv key, auto-discovery, etc.
+    argv = [fun]
+    argv.extend([salt.utils.json.dumps(arg) for arg in args])
+    argv.extend(
+        [
+            "{0}={1}".format(
+                salt.utils.stringutils.to_str(key), salt.utils.json.dumps(val)
+            )
+            for key, val in six.iteritems(kwargs)
+        ]
+    )
     conn = salt.client.ssh.Single(
-        opts, [fun], opts['id'], fsclient=fsclient, **opts['proxy']
+        opts, argv, opts['id'], fsclient=fsclient, **opts['proxy']
     )
     conn.args = args
     conn.kwargs = kwargs


### PR DESCRIPTION
Follow up from issue #179 

When calling for example `cmd.run` in a Saltfile setup, it will error with:

```
[ERROR   ] [minionid] Passed invalid arguments: run() missing 1 required positional argument: 'cmd'.
```

and then return the documentation.

I noticed `salt-ssh` constructed the client passing the arguments as parameters. This fixes the issue for me.

Disclaimer: I haven't tested this patch with a proper master setup, only as a local `salt-ssh` replacement. I am also not completely familiar with the way the function arguments are passed here.