### PR TITLE
Execute test.ping against the targeted Minions only when requested

### DIFF
--- a/salt_sproxy/_runners/proxy.py
+++ b/salt_sproxy/_runners/proxy.py
@@ -211,7 +211,9 @@ class NoPingBatch(Batch):
     that the Minions are up and running.
     '''
 
-    def __init__(self, opts, eauth=None, quiet=False, parser=None):
+    def __init__(
+        self, opts, eauth=None, quiet=False, parser=None
+    ):  # pylint: disable=super-init-not-called
         self.opts = opts
         self.eauth = eauth if eauth else {}
         self.pub_kwargs = eauth if eauth else {}

--- a/salt_sproxy/parsers.py
+++ b/salt_sproxy/parsers.py
@@ -298,7 +298,6 @@ class SaltStandaloneProxyOptionParser(
             '-b',
             '--batch',
             '--batch-size',
-            default=CPU_COUNT,
             dest='batch_size',
             help=(
                 'The number of devices to connect to in parallel. '

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,15 @@ setup(
     ],
     url='https://github.com/mirceaulinic/salt-sproxy',
     license="Apache License 2.0",
-    keywords=('salt', 'network', 'automation', 'cli', 'proxy', 'minion', 'salt-extension'),
+    keywords=(
+        'salt',
+        'network',
+        'automation',
+        'cli',
+        'proxy',
+        'minion',
+        'salt-extension',
+    ),
     project_urls={
         'CI: GitHub Actions': '{}/actions'.format(repo_url),
         'Docs: RTD': 'https://salt-sproxy.readthedocs.io/',

--- a/tests/run/cli.sh
+++ b/tests/run/cli.sh
@@ -27,29 +27,29 @@ echo "Syncing the sproxy Runner"
 salt-run saltutil.sync_runners
 
 echo "Roster processing correctly with --preview-target"
-salt-sproxy \* --preview --out=json | jq -e '. | length == 105'
+salt-sproxy \* --preview --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Grain targeting from Roster"
-salt-sproxy -G role:router --preview --out=json | jq -e '. == ["router1", "router2"]'
+salt-sproxy -G role:router --preview --out=json -l $LOG_LEVEL | jq -e '. == ["router1", "router2"]'
 
 echo "Grain targeting from Master config file"
-salt-sproxy -G salt:role:proxy --preview --out=json | jq -e '. | length == 105'
+salt-sproxy -G salt:role:proxy --preview --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "test.ping against the entire pool"
-salt-sproxy \* test.ping -p --static --out=json | jq -e '. | length == 105'
+salt-sproxy \* test.ping -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Testing batch size execution as percentage"
-salt-sproxy \* test.ping -b 20% -p --static --out=json | jq -e '. | length == 105'
+salt-sproxy \* test.ping -b 20% -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Test invasive targeting"
 # the nodename Grain is collected only on Minion startup, which helps validate
 # whether the --invasive-targeting works well
-salt-sproxy -G nodename:$(hostname) test.ping --invasive-targeting --cache-grains -p --static --out=json | jq -e '. | length == 105'
+salt-sproxy -G nodename:$(hostname) test.ping --invasive-targeting --cache-grains -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Test targeting using cached grains"
 # The exact query as above, now targeting using the cached Grains (saved earlier
 # through the --cache-grains option from the previous run).
-salt-sproxy -G nodename:$(hostname) test.ping -p --static --out=json | jq -e '. | length == 105'
+salt-sproxy -G nodename:$(hostname) test.ping -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Test execution through the salt-sapi"
 curl -sS localhost:8080/run -H 'Accept: application/json' \

--- a/tests/run/cli.sh
+++ b/tests/run/cli.sh
@@ -41,14 +41,19 @@ salt-sproxy \* test.ping -p --static --out=json -l $LOG_LEVEL | jq -e '. | lengt
 echo "Testing batch size execution as percentage"
 salt-sproxy \* test.ping -b 20% -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
-echo "Test invasive targeting"
+echo "Test invasive targeting, no cache"
 # the nodename Grain is collected only on Minion startup, which helps validate
 # whether the --invasive-targeting works well
-salt-sproxy -G nodename:$(hostname) test.ping --invasive-targeting --cache-grains -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
+salt-sproxy -G nodename:$(hostname) test.ping --invasive-targeting -p --static --dont-cache-grains --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
+
+echo "Test invasive targeting, cache Grains"
+# the nodename Grain is collected only on Minion startup, which helps validate
+# whether the --invasive-targeting works well
+salt-sproxy -G nodename:$(hostname) test.ping --invasive-targeting -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Test targeting using cached grains"
-# The exact query as above, now targeting using the cached Grains (saved earlier
-# through the --cache-grains option from the previous run).
+# The exact query as above, now targeting using the cached Grains (saved by the
+# previous execution, by default).
 salt-sproxy -G nodename:$(hostname) test.ping -p --static --out=json -l $LOG_LEVEL | jq -e '. | length == 105'
 
 echo "Test execution through the salt-sapi"


### PR DESCRIPTION
Basically, honour the `--test-ping` CLI arg (or `test_ping` config option).