### PR TITLE
Fix #240: Salt 3003.1 KeyError __runner__

### DIFF
--- a/salt_sproxy/_roster/file.py
+++ b/salt_sproxy/_roster/file.py
@@ -29,6 +29,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
     '''
     template = get_roster_file(__opts__)
     rend = salt.loader.render(__opts__, {})
+    __runner__.name = '__salt__'
     kwargs['__salt__'] = __runner__
     pool = compile_template(
         template,


### PR DESCRIPTION
It seems like in Salt 3003.1, there were some changes around the way
objects are loaded, and then indexed by their ``name`` attribute. As
we're injecting the ``__runner__`` object and make it available as the
``__salt__`` dunder, it also requires to update the obj name.