### PR TITLE
Fix #263: Salt3005rc1 raises AttributeError: 'SaltStandaloneProxy' obj…

### DIFF
--- a/salt_sproxy/cli.py
+++ b/salt_sproxy/cli.py
@@ -30,6 +30,7 @@ from salt.exceptions import SaltClientError
 from salt.ext import six
 import salt.defaults.exitcodes  # pylint: disable=W0611
 import salt.utils.stringutils
+import salt.version
 
 try:
     from salt.utils.files import fopen
@@ -62,9 +63,11 @@ class SaltStandaloneProxy(SaltStandaloneProxyOptionParser):
             sys.stdout.write(safe_dump(self.config, default_flow_style=False))
             return self.config
 
-        # Setup file logging!
-        self.setup_logfile_logger()
-        verify_log(self.config)
+        if salt.version.__saltstack_version__.major < 3005:
+            # Setup file logging!
+            self.setup_logfile_logger()
+            verify_log(self.config)
+
         profiling_enabled = self.options.profiling_enabled
         curpath = os.path.dirname(os.path.realpath(__file__))
         saltenv = self.config.get('saltenv_cli', self.config.get('saltenv'))


### PR DESCRIPTION
…ect has no attribute 'setup_logfile_logger'

This fixes issue #263 by putting the deprecated logging statements behind a version check as suggested by @network-shark. It would be nice to get this fixed now that 3005 has been released as it has broken salt-sproxy using debian 11 with the official apt repo.